### PR TITLE
Improve extra item aura refresh timing for fishing buffs

### DIFF
--- a/Angleur.lua
+++ b/Angleur.lua
@@ -115,6 +115,11 @@ local function checkMounted()
 end
 local firstCast = true
 local fishingSpellTable = AngleurRetail_FishingSpellTable
+
+local function updateFishingChannelDuration()
+    Angleur_UpdateFishingChannelDurationFromUnit("player")
+end
+
 function Angleur_LogicVariableHandler(self, event, unit, ...)
     local arg4, arg5 = ...
     -- Needed for when player zones into dungeon while mounted. Zone changes but no reload, and mount journal change doesn"t register
@@ -163,6 +168,7 @@ function Angleur_LogicVariableHandler(self, event, unit, ...)
     elseif event == "UNIT_SPELLCAST_CHANNEL_START" and not issecretvalue(unit) and unit == "player" then
         if issecretvalue(arg5) then return end
         if not CheckTable(fishingSpellTable, arg5) then return end
+        updateFishingChannelDuration()
         midFishing = true
         EventRegistry:TriggerEvent("Angleur_StartFishing")
         Angleur_ActionHandler(Angleur)
@@ -550,7 +556,8 @@ local function checkConditions(self, slot, assignKey)
             return false
         end
     end
-    if slot.name ~= 0 and slot.auraActive == false then
+    local auraBlocksReuse = Angleur_DoesExtraItemAuraBlockReuse(slot)
+    if slot.name ~= 0 and auraBlocksReuse == false then
         if checkUsabilityItem(slot.itemID) == false then return false end
         SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
         self.toyButton:SetAttribute("macrotext", "/cast " .. slot.name)
@@ -563,7 +570,7 @@ local function checkConditions(self, slot, assignKey)
         end
         if slot.macroSpellID ~= 0 and C_Spell.DoesSpellExist(slot.macroSpellID) and C_Spell.IsSpellUsable(slot.macroSpellID) then
             local spellCooldown = C_Spell.GetSpellCooldown(slot.macroSpellID).duration
-            if spellCooldown ~= 0 or slot.auraActive == true then return false end
+            if spellCooldown ~= 0 or auraBlocksReuse == true then return false end
             if parseMacroConditions(slot.macroBody) == true then
                 SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
                 self.toyButton:SetAttribute("macrotext", slot.macroBody)

--- a/Angleur.toc
+++ b/Angleur.toc
@@ -31,6 +31,7 @@ angTemplates\embeds.xml
 
 debug.lua
 init.lua
+items\extra_item_aura_logic.lua
 Angleur.lua
 
 toys\toys_retail.lua

--- a/AngleurMists.lua
+++ b/AngleurMists.lua
@@ -167,6 +167,11 @@ local function checkMounted()
     return false
 end
 local fishingSpellTable = AngleurMoP_FishingSpellTable
+
+local function updateFishingChannelDuration()
+    Angleur_UpdateFishingChannelDurationFromUnit("player")
+end
+
 function Angleur_LogicVariableHandler(self, event, unit, ...)
     local arg4, arg5, arg6 = ...
     
@@ -213,6 +218,7 @@ function Angleur_LogicVariableHandler(self, event, unit, ...)
         Angleur_ActionHandler(Angleur)
     elseif event == "UNIT_SPELLCAST_CHANNEL_START" and unit == "player" then
         if not CheckTable(fishingSpellTable, arg5) then return end
+        updateFishingChannelDuration()
         midFishing = true
         EventRegistry:TriggerEvent("Angleur_StartFishing")
         if AngleurClassicConfig.softInteract.enabled == true and AngleurClassicConfig.softInteract.warningSound == true then
@@ -653,7 +659,8 @@ local function checkConditions(self, slot, assignKey)
             return false
         end
     end
-    if slot.name ~= 0 and slot.auraActive == false then
+    local auraBlocksReuse = Angleur_DoesExtraItemAuraBlockReuse(slot)
+    if slot.name ~= 0 and auraBlocksReuse == false then
         if checkUsabilityItem(slot.itemID) == false then return false end
         SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
         self.toyButton:SetAttribute("macrotext", "/cast " .. slot.name)
@@ -666,7 +673,7 @@ local function checkConditions(self, slot, assignKey)
         end
         if slot.macroSpellID ~= 0 and C_Spell.DoesSpellExist(slot.macroSpellID) and IsUsableSpell(slot.macroSpellID) then
             local _, spellCooldown = GetSpellCooldown(slot.macroSpellID)
-            if spellCooldown ~= 0 or slot.auraActive == true then return false end
+            if spellCooldown ~= 0 or auraBlocksReuse == true then return false end
             if parseMacroConditions(slot.macroBody) == true then
                 SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
                 self.toyButton:SetAttribute("macrotext", slot.macroBody)

--- a/AngleurTBC.lua
+++ b/AngleurTBC.lua
@@ -143,6 +143,11 @@ local function checkMounted()
     return false
 end
 local fishingSpellTable = AngleurVanilla_FishingSpellTable
+
+local function updateFishingChannelDuration()
+    Angleur_UpdateFishingChannelDurationFromUnit("player")
+end
+
 function Angleur_LogicVariableHandler(self, event, unit, ...)
     local arg4, arg5, arg6 = ...
     -- Needed for when player zones into dungeon while mounted. Zone changes but no reload, and mount journal change doesn"t register.
@@ -188,6 +193,7 @@ function Angleur_LogicVariableHandler(self, event, unit, ...)
         Angleur_ActionHandler(Angleur)
     elseif event == "UNIT_SPELLCAST_CHANNEL_START" and unit == "player" then
         if not CheckTable(fishingSpellTable, arg5) then return end
+        updateFishingChannelDuration()
         midFishing = true
         EventRegistry:TriggerEvent("Angleur_StartFishing")
         if AngleurClassicConfig.softInteract.enabled == true and AngleurClassicConfig.softInteract.warningSound == true then
@@ -561,7 +567,8 @@ local function checkConditions(self, slot, assignKey)
             return false
         end
     end
-    if slot.name ~= 0 and slot.auraActive == false then
+    local auraBlocksReuse = Angleur_DoesExtraItemAuraBlockReuse(slot)
+    if slot.name ~= 0 and auraBlocksReuse == false then
         if checkUsabilityItem(slot.itemID) == false then return false end
         SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
         self.toyButton:SetAttribute("macrotext", "/cast " .. slot.name)
@@ -574,7 +581,7 @@ local function checkConditions(self, slot, assignKey)
         end
         if slot.macroSpellID ~= 0 and C_Spell.DoesSpellExist(slot.macroSpellID) and IsUsableSpell(slot.macroSpellID) then
             local _, spellCooldown = GetSpellCooldown(slot.macroSpellID)
-            if spellCooldown ~= 0 or slot.auraActive == true then return false end
+            if spellCooldown ~= 0 or auraBlocksReuse == true then return false end
             if parseMacroConditions(slot.macroBody) == true then
                 SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
                 self.toyButton:SetAttribute("macrotext", slot.macroBody)

--- a/AngleurVanilla.lua
+++ b/AngleurVanilla.lua
@@ -143,6 +143,11 @@ local function checkMounted()
     return false
 end
 local fishingSpellTable = AngleurVanilla_FishingSpellTable
+
+local function updateFishingChannelDuration()
+    Angleur_UpdateFishingChannelDurationFromUnit("player")
+end
+
 function Angleur_LogicVariableHandler(self, event, unit, ...)
     local arg4, arg5, arg6 = ...
     -- Needed for when player zones into dungeon while mounted. Zone changes but no reload, and mount journal change doesn"t register.
@@ -188,6 +193,7 @@ function Angleur_LogicVariableHandler(self, event, unit, ...)
         Angleur_ActionHandler(Angleur)
     elseif event == "UNIT_SPELLCAST_CHANNEL_START" and unit == "player" then
         if not CheckTable(fishingSpellTable, arg5) then return end
+        updateFishingChannelDuration()
         midFishing = true
         EventRegistry:TriggerEvent("Angleur_StartFishing")
         if AngleurClassicConfig.softInteract.enabled == true and AngleurClassicConfig.softInteract.warningSound == true then
@@ -560,7 +566,8 @@ local function checkConditions(self, slot, assignKey)
             return false
         end
     end
-    if slot.name ~= 0 and slot.auraActive == false then
+    local auraBlocksReuse = Angleur_DoesExtraItemAuraBlockReuse(slot)
+    if slot.name ~= 0 and auraBlocksReuse == false then
         if checkUsabilityItem(slot.itemID) == false then return false end
         SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
         self.toyButton:SetAttribute("macrotext", "/cast " .. slot.name)
@@ -573,7 +580,7 @@ local function checkConditions(self, slot, assignKey)
         end
         if slot.macroSpellID ~= 0 and C_Spell.DoesSpellExist(slot.macroSpellID) and IsUsableSpell(slot.macroSpellID) then
             local _, spellCooldown = GetSpellCooldown(slot.macroSpellID)
-            if spellCooldown ~= 0 or slot.auraActive == true then return false end
+            if spellCooldown ~= 0 or auraBlocksReuse == true then return false end
             if parseMacroConditions(slot.macroBody) == true then
                 SetOverrideBindingClick_Custom(self, true, assignKey, "Angleur_ToyButton")
                 self.toyButton:SetAttribute("macrotext", slot.macroBody)

--- a/Angleur_Mists.toc
+++ b/Angleur_Mists.toc
@@ -31,6 +31,7 @@ angTemplates\embeds.xml
 
 debug.lua
 init.lua
+items\extra_item_aura_logic.lua
 AngleurMists.lua
 
 toys\toys_mists.lua

--- a/Angleur_TBC.toc
+++ b/Angleur_TBC.toc
@@ -32,6 +32,7 @@ angTemplates\embeds.xml
 
 debug.lua
 init.lua
+items\extra_item_aura_logic.lua
 AngleurTBC.lua
 
 items\items_mists.lua

--- a/Angleur_Vanilla.toc
+++ b/Angleur_Vanilla.toc
@@ -31,6 +31,7 @@ angTemplates\embeds.xml
 
 debug.lua
 init.lua
+items\extra_item_aura_logic.lua
 AngleurVanilla.lua
 
 items\items_mists.lua

--- a/items/extra_item_aura_logic.lua
+++ b/items/extra_item_aura_logic.lua
@@ -1,0 +1,72 @@
+Angleur_ExtraItemAuraFallbackRefreshThreshold = 30
+Angleur_LastFishingChannelDuration = nil
+
+function Angleur_ClearFishingChannelDuration()
+    Angleur_LastFishingChannelDuration = nil
+end
+
+function Angleur_SetFishingChannelDuration(durationSeconds)
+    if type(durationSeconds) ~= "number" or durationSeconds <= 0 then
+        return
+    end
+
+    Angleur_LastFishingChannelDuration = durationSeconds
+end
+
+function Angleur_UpdateFishingChannelDurationFromUnit(unit)
+    local _, _, _, startTimeMs, endTimeMs = UnitChannelInfo(unit or "player")
+    if not startTimeMs or not endTimeMs then
+        Angleur_ClearFishingChannelDuration()
+        return false
+    end
+
+    Angleur_SetFishingChannelDuration((endTimeMs - startTimeMs) / 1000)
+    return true
+end
+
+function Angleur_GetExtraItemAuraRefreshThreshold()
+    return Angleur_LastFishingChannelDuration or Angleur_ExtraItemAuraFallbackRefreshThreshold
+end
+
+function Angleur_GetExtraItemAuraRemainingDuration(auraData, currentTime)
+    if not auraData then return nil end
+
+    local expirationTime = auraData.expirationTime
+    if not expirationTime or expirationTime == 0 then
+        return nil
+    end
+
+    return expirationTime - currentTime
+end
+
+function Angleur_ShouldBlockExtraItemAuraReuse(auraData, currentTime, refreshThreshold)
+    if not auraData then
+        return false
+    end
+
+    local remainingDuration = Angleur_GetExtraItemAuraRemainingDuration(auraData, currentTime)
+    if remainingDuration == nil then
+        return true
+    end
+
+    return remainingDuration >= (refreshThreshold or Angleur_GetExtraItemAuraRefreshThreshold())
+end
+
+function Angleur_DoesExtraItemAuraBlockReuse(slot)
+    local spellAuraID
+    if slot.spellID ~= 0 then
+        spellAuraID = slot.spellID
+    elseif slot.macroSpellID ~= 0 then
+        spellAuraID = slot.macroSpellID
+    else
+        return false
+    end
+
+    local spellInfo = C_Spell.GetSpellInfo(spellAuraID)
+    if not spellInfo or not spellInfo.name then
+        return false
+    end
+
+    local auraData = C_UnitAuras.GetAuraDataBySpellName("player", spellInfo.name)
+    return Angleur_ShouldBlockExtraItemAuraReuse(auraData, GetTime())
+end


### PR DESCRIPTION
## Summary

This PR updates extra item and macro aura refresh behavior so Angleur can reapply before the buff fully expires, using fishing channel timing instead of waiting for aura removal.

Closes #30.

## Changes

- add shared extra-item aura reuse logic for retail and classic variants
- refresh extra items and macros when remaining aura time drops below the refresh threshold instead of only after expiration
- measure the fishing channel duration from `UnitChannelInfo("player")` and use that as the preferred refresh threshold
- fall back to a `30` second threshold when no live fishing channel duration is available
- clear cached channel duration on failed reads so stale timing data is not reused
- add a standalone Lua regression script covering fallback and dynamic-threshold behavior

## Validation

- editor diagnostics show no errors in the changed Lua files
- standalone Lua regression script was updated, but could not be executed in this workspace because no `lua` or `luajit` runtime is available on `PATH`
